### PR TITLE
Add WiFi repeater mode

### DIFF
--- a/platforms/tab5/main/hal/components/hal_wifi.cpp
+++ b/platforms/tab5/main/hal/components/hal_wifi.cpp
@@ -25,51 +25,124 @@
 #define WIFI_PASS    ""
 #define MAX_STA_CONN 4
 
-// HTTP 处理函数
-esp_err_t hello_get_handler(httpd_req_t* req)
-{
-    const char* html_response = R"rawliteral(
-        <!DOCTYPE html>
-        <html>
-        <head>
-            <title>Hello</title>
-            <style>
-                body {
-                    display: flex;
-                    flex-direction: column;
-                    justify-content: center;
-                    align-items: center;
-                    height: 100vh;
-                    margin: 0;
-                    font-family: sans-serif;
-                    background-color: #f0f0f0;
-                }
-                h1 {
-                    font-size: 48px;
-                    color: #333;
-                    margin: 0;
-                }
-                p {
-                    font-size: 18px;
-                    color: #666;
-                    margin-top: 10px;
-                }
-            </style>
-        </head>
-        <body>
-            <h1>Hello World</h1>
-            <p>From M5Tab5</p>
-        </body>
-        </html>
-    )rawliteral";
+static char g_ap_ssid[32]  = WIFI_SSID;
+static char g_sta_ssid[32] = "";
+static char g_sta_pass[64] = "";
+static bool g_wifi_started = false;
 
-    httpd_resp_set_type(req, "text/html");
-    httpd_resp_send(req, html_response, HTTPD_RESP_USE_STRLEN);
-    return ESP_OK;
+static void url_decode(char* dst, const char* src)
+{
+    char a, b;
+    while (*src) {
+        if ((*src == '%') && ((a = src[1]) && (b = src[2])) && isxdigit(a) && isxdigit(b)) {
+            a      = (a >= 'a') ? a - 'a' + 10 : (a >= 'A') ? a - 'A' + 10 : a - '0';
+            b      = (b >= 'a') ? b - 'a' + 10 : (b >= 'A') ? b - 'A' + 10 : b - '0';
+            *dst++ = 16 * a + b;
+            src += 3;
+        } else if (*src == '+') {
+            *dst++ = ' ';
+            src++;
+        } else {
+            *dst++ = *src++;
+        }
+    }
+    *dst = '\0';
 }
 
-// URI 路由
-httpd_uri_t hello_uri = {.uri = "/", .method = HTTP_GET, .handler = hello_get_handler, .user_ctx = nullptr};
+static void wifi_reconfigure()
+{
+    if (g_wifi_started) {
+        esp_wifi_stop();
+    }
+
+    wifi_config_t ap_config = {};
+    strncpy(reinterpret_cast<char*>(ap_config.ap.ssid), g_ap_ssid, sizeof(ap_config.ap.ssid));
+    ap_config.ap.ssid_len       = strlen(g_ap_ssid);
+    ap_config.ap.max_connection = MAX_STA_CONN;
+    ap_config.ap.authmode       = WIFI_AUTH_OPEN;
+
+    wifi_config_t sta_config = {};
+    if (strlen(g_sta_ssid) > 0) {
+        strncpy(reinterpret_cast<char*>(sta_config.sta.ssid), g_sta_ssid, sizeof(sta_config.sta.ssid));
+        strncpy(reinterpret_cast<char*>(sta_config.sta.password), g_sta_pass, sizeof(sta_config.sta.password));
+    }
+
+    ESP_ERROR_CHECK(esp_wifi_set_mode(WIFI_MODE_APSTA));
+    ESP_ERROR_CHECK(esp_wifi_set_config(WIFI_IF_AP, &ap_config));
+    if (strlen(g_sta_ssid) > 0) {
+        ESP_ERROR_CHECK(esp_wifi_set_config(WIFI_IF_STA, &sta_config));
+    }
+
+    ESP_ERROR_CHECK(esp_wifi_start());
+    g_wifi_started = true;
+    if (strlen(g_sta_ssid) > 0) {
+        esp_wifi_connect();
+    }
+}
+
+// HTTP handler: configuration page
+esp_err_t config_get_handler(httpd_req_t* req)
+{
+    // The HTML page contains several input fields for SSIDs and password.
+    // With maximum lengths of the credentials the generated page can exceed
+    // 512 bytes, which triggered a -Wformat-truncation build error.
+    // Use a larger buffer to hold the entire page comfortably.
+    char html[768];
+    snprintf(html, sizeof(html),
+             R"rawliteral(
+<!DOCTYPE html>
+<html>
+  <head><title>M5Tab5 WiFi</title></head>
+  <body>
+    <h2>WiFi Settings</h2>
+    <form action='/config' method='post'>
+      <h3>Access Point</h3>
+      SSID:<input name='ap_ssid' value='%s'><br>
+      <h3>Station</h3>
+      SSID:<input name='sta_ssid' value='%s'><br>
+      Password:<input type='password' name='sta_pass' value='%s'><br>
+      <input type='submit' value='Save'>
+    </form>
+  </body>
+</html>
+)rawliteral",
+             g_ap_ssid, g_sta_ssid, g_sta_pass);
+
+    httpd_resp_set_type(req, "text/html");
+    return httpd_resp_send(req, html, HTTPD_RESP_USE_STRLEN);
+}
+
+// HTTP handler: receive configuration
+esp_err_t config_post_handler(httpd_req_t* req)
+{
+    char buf[256];
+    int received = httpd_req_recv(req, buf, MIN(req->content_len, sizeof(buf) - 1));
+    if (received <= 0) {
+        return ESP_FAIL;
+    }
+    buf[received] = '\0';
+
+    char* tok = strtok(buf, "&");
+    while (tok) {
+        if (strncmp(tok, "ap_ssid=", 8) == 0) {
+            url_decode(g_ap_ssid, tok + 8);
+        } else if (strncmp(tok, "sta_ssid=", 9) == 0) {
+            url_decode(g_sta_ssid, tok + 9);
+        } else if (strncmp(tok, "sta_pass=", 9) == 0) {
+            url_decode(g_sta_pass, tok + 9);
+        }
+        tok = strtok(NULL, "&");
+    }
+
+    wifi_reconfigure();
+
+    httpd_resp_set_type(req, "text/plain");
+    return httpd_resp_send(req, "OK", HTTPD_RESP_USE_STRLEN);
+}
+
+// URI routes
+httpd_uri_t root_uri = {.uri = "/", .method = HTTP_GET, .handler = config_get_handler, .user_ctx = nullptr};
+httpd_uri_t post_uri = {.uri = "/config", .method = HTTP_POST, .handler = config_post_handler, .user_ctx = nullptr};
 
 // 启动 Web Server
 httpd_handle_t start_webserver()
@@ -78,39 +151,30 @@ httpd_handle_t start_webserver()
     httpd_handle_t server = nullptr;
 
     if (httpd_start(&server, &config) == ESP_OK) {
-        httpd_register_uri_handler(server, &hello_uri);
+        httpd_register_uri_handler(server, &root_uri);
+        httpd_register_uri_handler(server, &post_uri);
     }
     return server;
 }
 
-// 初始化 Wi-Fi AP 模式
-void wifi_init_softap()
+// Initialize Wi-Fi in AP+STA mode
+void wifi_init_apsta()
 {
     ESP_ERROR_CHECK(esp_netif_init());
     ESP_ERROR_CHECK(esp_event_loop_create_default());
 
     esp_netif_create_default_wifi_ap();
+    esp_netif_create_default_wifi_sta();
 
     wifi_init_config_t cfg = WIFI_INIT_CONFIG_DEFAULT();
     ESP_ERROR_CHECK(esp_wifi_init(&cfg));
 
-    wifi_config_t wifi_config = {};
-    std::strncpy(reinterpret_cast<char*>(wifi_config.ap.ssid), WIFI_SSID, sizeof(wifi_config.ap.ssid));
-    std::strncpy(reinterpret_cast<char*>(wifi_config.ap.password), WIFI_PASS, sizeof(wifi_config.ap.password));
-    wifi_config.ap.ssid_len       = std::strlen(WIFI_SSID);
-    wifi_config.ap.max_connection = MAX_STA_CONN;
-    wifi_config.ap.authmode       = WIFI_AUTH_OPEN;
-
-    ESP_ERROR_CHECK(esp_wifi_set_mode(WIFI_MODE_AP));
-    ESP_ERROR_CHECK(esp_wifi_set_config(WIFI_IF_AP, &wifi_config));
-    ESP_ERROR_CHECK(esp_wifi_start());
-
-    ESP_LOGI(TAG, "Wi-Fi AP started. SSID:%s password:%s", WIFI_SSID, WIFI_PASS);
+    wifi_reconfigure();
 }
 
 static void wifi_ap_test_task(void* param)
 {
-    wifi_init_softap();
+    wifi_init_apsta();
     start_webserver();
 
     while (1) {


### PR DESCRIPTION
## Summary
- allow configuring AP and STA SSIDs via web interface
- run WiFi in AP+STA mode and reconnect when settings change
- enlarge HTML buffer to avoid -Wformat-truncation
- run clang-format on `hal_wifi.cpp`

## Testing
- `clang-format` (passed)
- `idf.py build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6846a776a694832194169015cec169fc