### PR TITLE
Fix Wi-Fi AP initialization

### DIFF
--- a/platforms/tab5/main/hal/components/hal_wifi.cpp
+++ b/platforms/tab5/main/hal/components/hal_wifi.cpp
@@ -206,5 +206,6 @@ bool HalEsp32::wifi_init()
 
 void HalEsp32::setExtAntennaEnable(bool enable)
 {
-
+    _ext_antenna_enable = enable;
+    mclog::tagInfo(TAG, "set ext antenna enable: {}", _ext_antenna_enable);
 }

--- a/platforms/tab5/main/hal/hal_esp32.cpp
+++ b/platforms/tab5/main/hal/hal_esp32.cpp
@@ -323,11 +323,11 @@ bool HalEsp32::usbCDetect()
 }
 
 bool HalEsp32::getExtAntennaEnable() {
-    return false; // alebo správnu logiku
+    return _ext_antenna_enable;
 }
 
 void HalEsp32::startWifiAp() {
-    // implementuj alebo nechaj prázdne
+    wifi_init();
 }
 
 bool HalEsp32::headPhoneDetect()


### PR DESCRIPTION
## Summary
- implement `startWifiAp` in `HalEsp32` so the Wi‑Fi access point starts
- implement `setExtAntennaEnable` and return stored state

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6846bc33f804832185fdc0668d99f77f