### PR TITLE
Simplify to WiFi AP demo

### DIFF
--- a/platforms/tab5/main/CMakeLists.txt
+++ b/platforms/tab5/main/CMakeLists.txt
@@ -1,19 +1,8 @@
-file(GLOB_RECURSE APP_LAYER_SRCS
-    ../../../app/*.c
-    ../../../app/*.cc
-    ../../../app/*.cpp
-)
-
-set(APP_LAYER_INCS
-    ../../../app
-)
-
 file(GLOB_RECURSE MY_HAL_SRCS
     ./hal/*.c
     ./hal/*.cc
     ./hal/*.cpp
 )
 
-idf_component_register(SRCS "app_main.cpp" ${APP_LAYER_SRCS} ${MY_HAL_SRCS}
-                    INCLUDE_DIRS "." ${APP_LAYER_INCS}
-                    EMBED_TXTFILES "../audio/canon_in_d.mp3" "../audio/startup_sfx.mp3" "../audio/shutdown_sfx.mp3")
+idf_component_register(SRCS "app_main.cpp" ${MY_HAL_SRCS}
+                    INCLUDE_DIRS ".")

--- a/platforms/tab5/main/app_main.cpp
+++ b/platforms/tab5/main/app_main.cpp
@@ -1,30 +1,25 @@
-/*
- * SPDX-FileCopyrightText: 2025 M5Stack Technology CO LTD
- *
- * SPDX-License-Identifier: MIT
- */
 #include "hal/hal_esp32.h"
-#include <app.h>
-#include <hal/hal.h>
-#include <memory>
+#include "hal/components/hal_wifi.h"
+#include <bsp/m5stack_tab5.h>
+#include <lvgl.h>
 #include <freertos/FreeRTOS.h>
 #include <freertos/task.h>
 
 extern "C" void app_main(void)
 {
-    // 应用层初始化回调
-    app::InitCallback_t callback;
+    HalEsp32 hal;
+    hal.startWifiAp();
 
-    callback.onHalInjection = []() {
-        // 注入桌面平台的硬件抽象
-        hal::Inject(std::make_unique<HalEsp32>());
-    };
+    lv_display_t* disp = bsp_display_start();
+    bsp_display_backlight_on();
 
-    // 应用层启动
-    app::Init(callback);
-    while (!app::IsDone()) {
-        app::Update();
-        vTaskDelay(1);
+    const char* ssid = hal_wifi_get_ap_ssid();
+    lv_obj_t* label = lv_label_create(lv_scr_act());
+    lv_label_set_text(label, ssid);
+    lv_obj_center(label);
+
+    while (true) {
+        lv_timer_handler();
+        vTaskDelay(pdMS_TO_TICKS(10));
     }
-    app::Destroy();
 }

--- a/platforms/tab5/main/hal/components/hal_wifi.cpp
+++ b/platforms/tab5/main/hal/components/hal_wifi.cpp
@@ -31,6 +31,11 @@ static char g_sta_ssid[32] = "";
 static char g_sta_pass[64] = "";
 static bool g_wifi_started = false;
 
+const char* hal_wifi_get_ap_ssid()
+{
+    return g_ap_ssid;
+}
+
 static void url_decode(char* dst, const char* src)
 {
     char a, b;

--- a/platforms/tab5/main/hal/components/hal_wifi.h
+++ b/platforms/tab5/main/hal/components/hal_wifi.h
@@ -1,0 +1,14 @@
+#pragma once
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#include <esp_http_server.h>
+
+const char* hal_wifi_get_ap_ssid();
+void wifi_init_apsta();
+httpd_handle_t start_webserver();
+
+#ifdef __cplusplus
+}
+#endif


### PR DESCRIPTION
## Summary
- streamline Tab5 firmware to a basic WiFi AP demo
- expose helper to read the AP SSID
- show AP SSID on the display
- drop application layer from build

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6846c4db95088321ba1794dc54835392